### PR TITLE
Export for ChartDataType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./api/create-chart";
 export * from "./api/chart-api";
+export type { ChartDataType } from './interfaces/chart';


### PR DESCRIPTION
Please see this issue: https://github.com/ddamiankowalski/light-trading-chart/issues/1

Added export for `ChartDataType`