### PR TITLE
API for setting horizontal margin and fixed y range on column renderer

### DIFF
--- a/src/api/chart-api.ts
+++ b/src/api/chart-api.ts
@@ -58,6 +58,17 @@ export class ChartAPI {
     this._overlayView && this._overlayView.updateColor(color);
   }
 
+  public setFixedYRange(range: { min: number, max: number }): void {
+    if (this._dataType !== 'COLUMNS') {
+      throw new Error('Cannot set range for this type of chart');
+    }
+
+    if (this._valueScaleView) {
+      this._valueScaleView.setRange(range);
+      this._dataView.setRange(range);
+    }
+  }
+
   public setHorizontalMargin(margin: number): void {
     if (this._dataType !== 'COLUMNS') {
       throw new Error('Cannot set horizontal margin for this type of chart');

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -1,15 +1,16 @@
 import { createChart } from ".";
 
-const chart = createChart(document.getElementById("app") as HTMLElement, "FULL", "COLUMNS", {
+const chart = createChart(document.getElementById("app") as HTMLElement, "FULL", "LINE", {
   stopTimeScaleConvert: true,
   showPercentagePrefix: true,
 });
 
-chart.setHorizontalMargin(100);
+//chart.setHorizontalMargin(100);
 
 chart.setData([
-  { x: "JANUARY", y: -100 },
-  { x: "MARCH", y: -200 },
-  { x: "April", y: -200 },
-  { x: "may", y: -200 },
+  { x: "JANUARY", y: 10 },
+  { x: "MARCH", y: 0 },
+  { x: "may", y: -50 },
 ]);
+
+//chart.setFixedYRange({ min: -100, max: 100 });

--- a/src/renderer/column-layer.ts
+++ b/src/renderer/column-layer.ts
@@ -1,3 +1,4 @@
+import { MinMaxSource } from "../interfaces/data-source";
 import { ColumnLayerView } from "../views/column-layer";
 
 export class ColumnLayerRenderer {
@@ -14,7 +15,15 @@ export class ColumnLayerRenderer {
   }
 
   get effectiveCanvasHeight(): number {
-    return this._view.height * 0.8;
+    return this._view.height * (this._view.minMax ? 1 : 0.8);
+  }
+
+  get minMax(): MinMaxSource {
+    if (this._view.minMax) {
+      return this._view.minMax;
+    }
+
+    return this._view.dataSource.minMax;
   }
 
 
@@ -22,7 +31,7 @@ export class ColumnLayerRenderer {
     this._ctx.save();
     this._ctx.scale(devicePixelRatio, devicePixelRatio);
 
-    const { min, max } = this._view.dataSource.minMax;
+    const { min, max } = this.minMax;
     const ratio = this._getYAxisRatio(min, max);
 
     this._resetCanvas();
@@ -32,6 +41,7 @@ export class ColumnLayerRenderer {
       const value = this._view.dataSource.source[i].y;
       const xCoord = i * this._getColGap(horizontalMargin);
       let yCoord = this._view.height - (value - min) * ratio;
+      console.log(this._view.height, value, min, ratio)
       let deltaYCoord = this._view.height - (0 - min) * ratio;
 
       this._drawBox(xCoord, yCoord, deltaYCoord, value, horizontalMargin);

--- a/src/renderer/value-scale.ts
+++ b/src/renderer/value-scale.ts
@@ -15,14 +15,13 @@ export class ValueScaleRenderer {
   }
 
   private _calculateRowDiff(): number {
-    const rowQuantity = Math.floor(this._view.height / 10);
-    return rowQuantity;
+    return Math.floor(this._view.height / 10);
   }
 
   private _createSvg(x: number, rowDiff: number): void {
     const minMax = this._view.minMax;
     const { min, max } = minMax;
-    const diff = Math.abs(max - min) / 8;
+    const diff = Math.abs(max - min) / (this._view.isFixedMinMax ? 9 : 8);
 
     for (let i = 0; i < 10; i++) {
       const text = (min + diff * i).toFixed(2).toString() + (this._chartOptions?.showPercentagePrefix ? "%" : "");

--- a/src/views/common-layer.ts
+++ b/src/views/common-layer.ts
@@ -15,6 +15,7 @@ export abstract class CommonLayerView {
   protected _hoverLineColor?: string;
   protected _verticalMargin: number = 6;
   protected _horizontalMargin: number = 60;
+  protected _minMax: { min: number; max: number } | null = null;
 
   constructor(
     protected _component: DataComponent,
@@ -45,6 +46,10 @@ export abstract class CommonLayerView {
     return this._horizontalMargin;
   }
 
+  get minMax(): { min: number; max: number } | null {
+    return this._minMax;
+  }
+
   get ctx(): CanvasRenderingContext2D {
     const context = this._canvas.getContext("2d");
 
@@ -69,6 +74,11 @@ export abstract class CommonLayerView {
   public updateHorizontalMargin(margin: number) {
     this._horizontalMargin = margin;
     this.render()
+  }
+
+  public setRange(range: { min: number, max: number }): void {
+    this._minMax = range;
+    this.render();
   }
 
   public updateColor(color: string) {

--- a/src/views/value-scale.ts
+++ b/src/views/value-scale.ts
@@ -9,6 +9,7 @@ export class ValueScaleView implements View, SourceView {
   private _svgContainer: SVGSVGElement;
   private _renderer: ValueScaleRenderer;
   private _minMax: MinMaxSource | null = null;
+  private _isFixedMinMax = false;
 
   constructor(
     private _component: ValueScaleComponent,
@@ -37,6 +38,16 @@ export class ValueScaleView implements View, SourceView {
     }
 
     return this._minMax;
+  }
+
+  get isFixedMinMax(): boolean {
+    return this._isFixedMinMax;
+  }
+
+  public setRange(range: { min: number, max: number }): void {
+    this._minMax = range;
+    this._isFixedMinMax = true;
+    this.render();
   }
 
   public invalidate(): void {


### PR DESCRIPTION
See issue: https://github.com/ddamiankowalski/light-trading-chart/issues/2

- Added `setHorizontalMargin` for column renderer
- Added `setFixedYRange` for column renderer